### PR TITLE
Fixes Issue #28

### DIFF
--- a/WLEmptyState/Classes/Protocols/WLEmptyStateProtocol.swift
+++ b/WLEmptyState/Classes/Protocols/WLEmptyStateProtocol.swift
@@ -53,7 +53,7 @@ extension WLEmptyStateProtocol where Self: UITableView {
     
     var numberOfItems: Int {
         var items = 0
-        let numberOfSections = dataSource?.numberOfSections?(in: self) ?? 0
+        let numberOfSections = dataSource?.numberOfSections?(in: self) ?? 1
         for section in 0..<numberOfSections {
             items += dataSource?.tableView(self, numberOfRowsInSection: section) ?? 0
         }
@@ -66,7 +66,7 @@ extension WLEmptyStateProtocol where Self: UICollectionView {
     
     var numberOfItems: Int {
         var items = 0
-        let numberOfSections = dataSource?.numberOfSections?(in: self) ?? 0
+        let numberOfSections = dataSource?.numberOfSections?(in: self) ?? 1
         for section in 0..<numberOfSections {
             items += dataSource?.collectionView(self, numberOfItemsInSection: section) ?? 0
         }


### PR DESCRIPTION
#### What does this PR do? Any background context you want to provide?
Empty State was always showing on `UIViewControllers` whom not implement the `numberOfSection`  method on both  `UICollectionView` and `UITableView`

#### Where should the reviewer start?
as for the default implementation of numberOfSections is 1 just added the default value on our `WLEmptyStateProtocol` Default Implementations for both views

#### How should this be manually tested?
Just create a UIViewController with a UITableView/UICollectionView with no `numberOfSections` explicit implementation and add some rows

#### What are the relevant tickets?
#28 

