### PR TITLE
Validate if emptyStateDataSource is nil

### DIFF
--- a/WLEmptyState/Classes/Extensions/UICollectionView+WLEmptyState.swift
+++ b/WLEmptyState/Classes/Extensions/UICollectionView+WLEmptyState.swift
@@ -44,6 +44,8 @@ extension UICollectionView: WLEmptyStateProtocol {
     }
     
     @objc private dynamic func swizzledReload() {
+        guard emptyStateDataSource != nil else { return }
+        
         swizzledReload()
         
         if numberOfItems == 0 && self.subviews.count > 1 {

--- a/WLEmptyState/Classes/Extensions/UITableView+WLEmptyState.swift
+++ b/WLEmptyState/Classes/Extensions/UITableView+WLEmptyState.swift
@@ -45,6 +45,8 @@ extension UITableView: WLEmptyStateProtocol {
     }
     
     @objc private dynamic func swizzledReload() {
+        guard emptyStateDataSource != nil else { return }
+
         swizzledReload()
         
         if numberOfItems == 0 && self.subviews.count > 1 {


### PR DESCRIPTION

#### What does this PR do? Any background context you want to provide?
This PR fix the issue [#40](https://github.com/wizeline/WLEmptyState/issues/40) where empty state always shown if there's not `emptyStateDataSource` implemented

#### Where should the reviewer start?
The order of the files are ok

#### How should this be manually tested?
1. Configure the empty state in the AppDelegate
2. Implement a UITableViewController
3. Run and compile the app
4. Click the Debug View Hierarchy button on Xcode and you don't see any the emptyStateView

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions
N/A