### PR TITLE
Fix issue #46 and #40

### DIFF
--- a/WLEmptyState/Classes/Extensions/UICollectionView+WLEmptyState.swift
+++ b/WLEmptyState/Classes/Extensions/UICollectionView+WLEmptyState.swift
@@ -79,7 +79,8 @@ extension UICollectionView: WLEmptyStateProtocol {
                 ])
             }
         } else {
-            removeEmptyView()
+            // NOTE: As `UICollectionView` is using `backgroundView` we're not calling `removeEmptyView`.
+            backgroundView = nil
             isScrollEnabled = originalScrollingValue
         }
     }

--- a/WLEmptyState/Classes/Extensions/UICollectionView+WLEmptyState.swift
+++ b/WLEmptyState/Classes/Extensions/UICollectionView+WLEmptyState.swift
@@ -57,7 +57,7 @@ extension UICollectionView: WLEmptyStateProtocol {
     @objc private dynamic func swizzledReload() {
         swizzledReload()
         
-        guard emptyStateDataSource != nil else { return }
+        guard let emptyStateDataSource = emptyStateDataSource else { return }
         
         if numberOfItems == 0 && self.subviews.count > 1 {
             originalScrollingValue = isScrollEnabled
@@ -65,10 +65,9 @@ extension UICollectionView: WLEmptyStateProtocol {
             
             backgroundView = emptyStateView
             if let emptyStateView = emptyStateView as? EmptyStateView {
-                let datasource = self.emptyStateDataSource
-                emptyStateView.titleLabel.attributedText = datasource?.titleForEmptyDataSet()
-                emptyStateView.descriptionLabel.attributedText = datasource?.descriptionForEmptyDataSet()
-                emptyStateView.image = datasource?.imageForEmptyDataSet()
+                emptyStateView.titleLabel.attributedText = emptyStateDataSource.titleForEmptyDataSet()
+                emptyStateView.descriptionLabel.attributedText = emptyStateDataSource.descriptionForEmptyDataSet()
+                emptyStateView.image = emptyStateDataSource.imageForEmptyDataSet()
             } else {
                 emptyStateView.translatesAutoresizingMaskIntoConstraints = false
                 NSLayoutConstraint.activate([

--- a/WLEmptyState/Classes/Extensions/UITableView+WLEmptyState.swift
+++ b/WLEmptyState/Classes/Extensions/UITableView+WLEmptyState.swift
@@ -58,7 +58,7 @@ extension UITableView: WLEmptyStateProtocol {
     @objc private dynamic func swizzledReload() {
         swizzledReload()
         
-        guard emptyStateDataSource != nil else { return }
+        guard let emptyStateDataSource = emptyStateDataSource else { return }
         
         if numberOfItems == 0 && self.subviews.count > 1 {
             originalScrollingValue = isScrollEnabled
@@ -66,10 +66,9 @@ extension UITableView: WLEmptyStateProtocol {
             
             addSubview(emptyStateView)
             if let emptyStateView = emptyStateView as? EmptyStateView {
-                let datasource = self.emptyStateDataSource
-                emptyStateView.titleLabel.attributedText = datasource?.titleForEmptyDataSet()
-                emptyStateView.descriptionLabel.attributedText = datasource?.descriptionForEmptyDataSet()
-                emptyStateView.image = datasource?.imageForEmptyDataSet()
+                emptyStateView.titleLabel.attributedText = emptyStateDataSource.titleForEmptyDataSet()
+                emptyStateView.descriptionLabel.attributedText = emptyStateDataSource.descriptionForEmptyDataSet()
+                emptyStateView.image = emptyStateDataSource.imageForEmptyDataSet()
             } else {
                 emptyStateView.translatesAutoresizingMaskIntoConstraints = false
                 NSLayoutConstraint.activate([


### PR DESCRIPTION
#### What does this PR do? Any background context you want to provide?
Fixes the removal of the empty state on `UICollectionView` when the dataset count is greater than `0`.
#### Where should the reviewer start?
* `WLEmptyState/Classes/Extensions/UICollectionView+WLEmptyState.swift`.
* `WLEmptyState/Classes/Extensions/UITableView+WLEmptyState.swift`.
#### How should this be manually tested?
Use the example app to modify the DataSource count. More info https://github.com/wizeline/WLEmptyState/issues/46
#### What are the relevant tickets?
https://github.com/wizeline/WLEmptyState/issues/46
https://github.com/wizeline/WLEmptyState/issues/40
#### Screenshots (if appropriate)
![Aug-03-2020 20-59-21](https://user-images.githubusercontent.com/6756995/89244509-44a61080-d5cc-11ea-9bf0-77b66f5ab305.gif)

<img width="519" alt="Screen Shot 2020-08-03 at 22 09 41" src="https://user-images.githubusercontent.com/6756995/89248927-8471f580-d5d6-11ea-9776-38edf9523a50.png">

#### Questions & Comments
* I think we should move out from using backgroundView just in case a developer is using a custom backgroundView