### PR TITLE
Improve accessibility support

### DIFF
--- a/Sources/WLEmptyState/Classes/Extensions/UICollectionView+WLEmptyState.swift
+++ b/Sources/WLEmptyState/Classes/Extensions/UICollectionView+WLEmptyState.swift
@@ -68,6 +68,7 @@ extension UICollectionView: WLEmptyStateProtocol {
                 emptyStateView.titleLabel.attributedText = emptyStateDataSource.titleForEmptyDataSet()
                 emptyStateView.descriptionLabel.attributedText = emptyStateDataSource.descriptionForEmptyDataSet()
                 emptyStateView.image = emptyStateDataSource.imageForEmptyDataSet()
+                emptyStateView.accessibilityDescription = emptyStateDataSource.accessibilityDescriptionForEmptyDataSet()
             } else {
                 emptyStateView.translatesAutoresizingMaskIntoConstraints = false
                 NSLayoutConstraint.activate([

--- a/Sources/WLEmptyState/Classes/Extensions/UITableView+WLEmptyState.swift
+++ b/Sources/WLEmptyState/Classes/Extensions/UITableView+WLEmptyState.swift
@@ -69,6 +69,7 @@ extension UITableView: WLEmptyStateProtocol {
                 emptyStateView.titleLabel.attributedText = emptyStateDataSource.titleForEmptyDataSet()
                 emptyStateView.descriptionLabel.attributedText = emptyStateDataSource.descriptionForEmptyDataSet()
                 emptyStateView.image = emptyStateDataSource.imageForEmptyDataSet()
+                emptyStateView.accessibilityDescription = emptyStateDataSource.accessibilityDescriptionForEmptyDataSet()
             } else {
                 emptyStateView.translatesAutoresizingMaskIntoConstraints = false
                 NSLayoutConstraint.activate([

--- a/Sources/WLEmptyState/Classes/Protocols/WLEmptyStateDataSource.swift
+++ b/Sources/WLEmptyState/Classes/Protocols/WLEmptyStateDataSource.swift
@@ -32,6 +32,12 @@ public protocol WLEmptyStateDataSource: class {
     /// - Returns: The custom view to be used.
     func customViewForEmptyState() -> UIView?
     
+    /// Ask the data source for a localized accessibility description to be used as the `EmptyStateView` accessibilityLabel string.
+    ///
+    /// - Returns: An optional localized string describing the empty view.
+    func accessibilityDescriptionForEmptyDataSet() -> String?
+
+    
 }
 
 // MARK: - WLEmptyStateDataSource Default
@@ -54,6 +60,10 @@ public extension WLEmptyStateDataSource {
         return nil
     }
     
+    func accessibilityDescriptionForEmptyDataSet() -> String? {
+        return nil
+    }
+
 }
 
 

--- a/Sources/WLEmptyState/Classes/Views/EmptyStateView.swift
+++ b/Sources/WLEmptyState/Classes/Views/EmptyStateView.swift
@@ -73,6 +73,16 @@ final class EmptyStateView: UIView {
         }
     }
     
+    var accessibilityDescription: String? {
+        get {
+            return self.containerView.accessibilityLabel
+        }
+        set {
+            self.containerView.isAccessibilityElement = (newValue != nil)
+            self.containerView.accessibilityLabel = newValue
+        }
+    }
+
     override public init(frame: CGRect) {
         super.init(frame: frame)
         

--- a/Sources/WLEmptyState/Classes/Views/EmptyStateView.swift
+++ b/Sources/WLEmptyState/Classes/Views/EmptyStateView.swift
@@ -44,6 +44,7 @@ final class EmptyStateView: UIView {
         let label = UILabel(frame: .zero)
         label.backgroundColor = .systemBackground
         label.textAlignment = .center
+        label.accessibilityTraits = [.header]
         return  label
     }()
     


### PR DESCRIPTION
#### What does this PR do? Any background context you want to provide?
Currently there's no easy way to set the accessibility label for the empty state view. This PR shows a proposal to allow the users to set an accessibility description for the empty state view. 

Also in this PR the accessibility trait `header` is added to the title label in order to improve the navigation while using the accessibility rotor.

#### In which scenarios can this be useful?

Giving the user an easy way to set the accessibility label can be useful on the following scenarios:

- When a user provides an empty string to the title and description of the empty view and wants to provide a localized description for the empty view

![showing an empty state view with no title or description](https://user-images.githubusercontent.com/32823124/99444920-75435900-28e2-11eb-8a14-67a2047e4837.png)

- When a user provides a title or description that relies on a visual element to provide the user context information

![showing an empty state view with no description and using visual characters to give the user contextual information](https://user-images.githubusercontent.com/32823124/99444935-78d6e000-28e2-11eb-8a56-ed2447da2815.png)

#### Where should the reviewer start?
- By using the project example you can add the following code to the `SampleTableViewController` or `SampleCollectionViewController`

```swift
func accessibilityDescriptionForEmptyDataSet() -> String? {
      return "This is a test for an accessible description"
}
```

#### How should this be manually tested?
- Activate VoiceOver
- Navigate through the title and description of an empty view
